### PR TITLE
CRB-206: Load plugins only once & other minor optimizations

### DIFF
--- a/ccgateway/Program.cs
+++ b/ccgateway/Program.cs
@@ -54,6 +54,15 @@ namespace ccgateway
                 ip = "127.0.0.1";
             }
 
+            var loader = new Loader<ICCGatewayPlugin>();
+            var msgs = new List<string>();
+
+            loader.Load(folder, msgs);
+            foreach (var msg in msgs)
+            {
+                Console.WriteLine(msg);
+            }
+
             using (var socket = new ResponseSocket())
             {
                 socket.Bind($"tcp://{ip}:55555");
@@ -75,26 +84,18 @@ namespace ccgateway
                         }
                         else
                         {
-                            var loader = new Loader<ICCGatewayPlugin>();
-                            var msgs = new List<string>();
-
-                            loader.Load(folder, msgs);
-                            foreach (var msg in msgs)
-                            {
-                                Console.WriteLine(msg);
-                            }
-
                             string action = command[0];
-                            command = command.Skip(1).ToArray();
-
                             ICCGatewayPlugin plugin = loader.Get(action);
-                            var pluginConfig = config.GetSection(action);
+
                             if (plugin == null)
                             {
                                 response = "miss";
                             }
                             else
                             {
+                                command = command.Skip(1).ToArray();
+                                var pluginConfig = config.GetSection(action);
+
                                 string msg;
                                 bool done = plugin.Run(pluginConfig, command, out msg);
                                 if (done)


### PR DESCRIPTION
- Don't load plugins on every iteration, aka message received. This
  service is running as a docker container and we'll need to stop/start
  the container if we want to update the plugins. I don't see a reason
  to load them upon receiving every message on the wire.

- Don't perform any other actions, even assigning to variables, before
  validating that the specified plugin exists.