### PR TITLE
CRB-279: Don't crash in case there's an exception

### DIFF
--- a/ccgateway/Program.cs
+++ b/ccgateway/Program.cs
@@ -119,16 +119,22 @@ namespace ccgateway
             {
                 frontEnd.ReceiveReady += (sender, args) =>
                 {
-                    var message = args.Socket.ReceiveMultipartMessage();
-                    var identity = message.First;
-                    var request = message[2].ConvertToString();
-
-                    ThreadPool.QueueUserWorkItem(async ctx =>
+                    try
                     {
-                        var (loader, id, contents) = (Tuple<Loader<ICCGatewayPluginAsync>, NetMQFrame, string>)ctx;
-                        await ProcessRequest(loader, id, contents);
-                    }, Tuple.Create(loader, identity, request));
+                        var message = args.Socket.ReceiveMultipartMessage();
+                        var identity = message.First;
+                        var request = message[2].ConvertToString();
 
+                        ThreadPool.QueueUserWorkItem(async ctx =>
+                        {
+                            var (loader, id, contents) = (Tuple<Loader<ICCGatewayPluginAsync>, NetMQFrame, string>)ctx;
+                            await ProcessRequest(loader, id, contents);
+                        }, Tuple.Create(loader, identity, request));
+                    }
+                    catch (System.ArgumentOutOfRangeException e)
+                    {
+                        Console.WriteLine($"{getTimestamp()}: Exception caught, won't crash: {e}");
+                    }
                 };
                 backEnd.ReceiveReady += (sender, args) =>
                 {


### PR DESCRIPTION
IMO this happens b/c on some of our nodes the gateway port is open to
the public and there could be crawler bots (or anything else) trying to
send malformed messages to this port.